### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,18 @@
+name: Add PRs to Dependabot PRs dashboard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add PR to dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/OpenLiberty/projects/26
+          github-token: ${{ secrets.ADMIN_BACKLOG }}
+          labeled: dependencies

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -19,8 +19,8 @@
         <!-- Default test properties -->
         <system.service.root>localhost:31000</system.service.root>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -42,19 +42,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -71,19 +71,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <system.service.root>${system.service.root}</system.service.root>

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -9,11 +9,11 @@
         <feature>ssl-1.0</feature>
     </featureManager>
 
-    <variable name="default.http.port" defaultValue="9080" />
-    <variable name="default.https.port" defaultValue="9443" />
+    <variable name="http.port" defaultValue="9080" />
+    <variable name="https.port" defaultValue="9443" />
 
-    <httpEndpoint host="*" httpPort="${default.http.port}"
-        httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+    <httpEndpoint host="*" httpPort="${http.port}"
+        httpsPort="${https.port}" id="defaultHttpEndpoint" />
 
     <webApplication location="guide-openliberty-operator-openshift-system.war" contextRoot="/" />
 </server>

--- a/finish/system/src/main/webapp/index.html
+++ b/finish/system/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 ​
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -19,8 +19,8 @@
         <!-- Default test properties -->
         <system.service.root>localhost:31000</system.service.root>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -42,19 +42,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -71,19 +71,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <system.service.root>${system.service.root}</system.service.root>

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -9,11 +9,11 @@
         <feature>ssl-1.0</feature>
     </featureManager>
 
-    <variable name="default.http.port" defaultValue="9080" />
-    <variable name="default.https.port" defaultValue="9443" />
+    <variable name="http.port" defaultValue="9080" />
+    <variable name="https.port" defaultValue="9443" />
 
-    <httpEndpoint host="*" httpPort="${default.http.port}"
-        httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+    <httpEndpoint host="*" httpPort="${http.port}"
+        httpsPort="${https.port}" id="defaultHttpEndpoint" />
 
     <webApplication location="guide-openliberty-operator-openshift-system.war" contextRoot="/" />
 </server>

--- a/start/system/src/main/webapp/index.html
+++ b/start/system/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 ​
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [x] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [x] server.xml
  - feature version
- [x] index.html
  - feature version
- [x] update lgdev with `version-update-mp61` branch
- [x] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

